### PR TITLE
Use get_all_paginated_results method

### DIFF
--- a/framework/http_client.py
+++ b/framework/http_client.py
@@ -60,3 +60,20 @@ class TestClient:
 
         # Verify expected status code
         assert_that(delete_resp).has_status_code(status_code)
+
+    def get_all_paginated_results(self, path, per_page=100):
+        # todo: If user base becomes too big, these results might not fit in memory.
+        #       In this case it would be better doing loop inside tests and asserting with each iteration
+        page = 1
+        all_results = []
+
+        while True:
+            page_resp = self.get(f'/{path}?page={page}&per_page={per_page}')
+
+            if not page_resp:
+                break
+
+            all_results.extend(page_resp)
+            page += 1
+
+        return all_results

--- a/go_rest_tests/model_tests/test_resources_on_user/test_valid_user_post.py
+++ b/go_rest_tests/model_tests/test_resources_on_user/test_valid_user_post.py
@@ -30,7 +30,6 @@ class TestUserPostCRUD:
             .is_equal_to(valid_post)
 
     def test_user_post_is_vended_in_user_unfiltered_posts(self, go_rest_client, valid_user_id, valid_post):
-        # todo: Account for pagination
         # GET all user posts
         get_resp = go_rest_client.get(f'/users/{valid_user_id}/posts/')
 

--- a/go_rest_tests/route_tests/test_comments/test_invalid_comment.py
+++ b/go_rest_tests/route_tests/test_comments/test_invalid_comment.py
@@ -46,9 +46,8 @@ class TestCommentInvalidCRUD:
         go_rest_client.post('/comments', invalid_comment.__dict__, status_code=422)
 
     def test_invalid_comment_not_in_unfiltered_comments(self, go_rest_client):
-        # todo: Account for pagination
         # GET all comments
-        get_resp = go_rest_client.get('/comments/')
+        get_resp = go_rest_client.get_all_paginated_results('/comments/')
 
         # Verify GET all comments response does not contain invalid data
         assert_that(get_resp, readable_json(get_resp))\

--- a/go_rest_tests/route_tests/test_comments/test_valid_comment.py
+++ b/go_rest_tests/route_tests/test_comments/test_valid_comment.py
@@ -28,9 +28,8 @@ class TestCommentCRUD:
             .is_equal_to(valid_comment)
 
     def test_new_comment_is_vended_in_unfiltered_users(self, go_rest_client, valid_comment):
-        # todo: Account for pagination
         # Retrieve unfiltered resources
-        get_resp = go_rest_client.get('/comments/')
+        get_resp = go_rest_client.get_all_paginated_results('/comments/')
 
         # Verify new resource data is vended in GET unfiltered resources response
         assert_that(get_resp, readable_json(get_resp))\

--- a/go_rest_tests/route_tests/test_posts/test_valid_post.py
+++ b/go_rest_tests/route_tests/test_posts/test_valid_post.py
@@ -28,9 +28,8 @@ class TestPostCRUD:
             .is_equal_to(valid_post)
 
     def test_new_post_is_vended_in_unfiltered_users(self, go_rest_client, valid_post):
-        # todo: Account for pagination
         # Retrieve unfiltered resources
-        get_resp = go_rest_client.get('/posts/')
+        get_resp = go_rest_client.get_all_paginated_results('/posts/')
 
         # Verify new resource data is vended in GET unfiltered resources response
         assert_that(get_resp, readable_json(get_resp))\

--- a/go_rest_tests/route_tests/test_todos/test_invalid_todo.py
+++ b/go_rest_tests/route_tests/test_todos/test_invalid_todo.py
@@ -50,9 +50,8 @@ class TestTodoInvalidCRUD:
         go_rest_client.post('/todos', invalid_todo.__dict__, status_code=422)
 
     def test_invalid_todo_not_in_unfiltered_todos(self, go_rest_client):
-        # todo: Account for pagination
         # GET all todos
-        get_resp = go_rest_client.get('/todos/')
+        get_resp = go_rest_client.get_all_paginated_results('/todos/')
 
         # Verify GET all todos response does not contain invalid data
         assert_that(get_resp, readable_json(get_resp))\

--- a/go_rest_tests/route_tests/test_todos/test_valid_todo.py
+++ b/go_rest_tests/route_tests/test_todos/test_valid_todo.py
@@ -29,9 +29,8 @@ class TestTodoCRUD:
             .is_equal_to(valid_todo)
 
     def test_new_todo_is_vended_in_unfiltered_users(self, go_rest_client, valid_todo):
-        # todo: Account for pagination
         # Retrieve unfiltered resources
-        get_resp = go_rest_client.get('/todos/')
+        get_resp = go_rest_client.get_all_paginated_results('/todos/')
 
         # Verify new resource data is vended in GET unfiltered resources response
         assert_that(get_resp, readable_json(get_resp))\

--- a/go_rest_tests/route_tests/test_user/test_invalid_user.py
+++ b/go_rest_tests/route_tests/test_user/test_invalid_user.py
@@ -34,9 +34,8 @@ class TestUserInvalidCRUD:
         go_rest_client.post('/users', invalid_user.__dict__, status_code=422)
 
     def test_invalid_user_not_in_unfiltered_users(self, go_rest_client):
-        # todo: Account for pagination
         # GET all users
-        get_resp = go_rest_client.get('/users/')
+        get_resp = go_rest_client.get_all_paginated_results('/users/')
 
         # Verify GET all users response does not contain invalid account
         assert_that(get_resp, readable_json(get_resp))\

--- a/go_rest_tests/route_tests/test_user/test_valid_user.py
+++ b/go_rest_tests/route_tests/test_user/test_valid_user.py
@@ -29,13 +29,18 @@ class TestUserCRUD:
             .is_equal_to(valid_user)
 
     def test_new_user_is_vended_in_unfiltered_users(self, go_rest_client, valid_user):
-        # todo: Account for pagination
         # Retrieve unfiltered resources
-        get_resp = go_rest_client.get('/users/')
+        page = 1
 
-        # Verify new resource data is vended in GET unfiltered resources response
-        assert_that(get_resp, readable_json(get_resp))\
-            .contains(valid_user)
+        while True:
+            if not (page_resp := go_rest_client.get(f'/users?page={page}&per_page=100')):
+                break
+
+            # Verify new resource data is vended in GET unfiltered resources response
+            assert_that(page_resp, readable_json(page_resp))\
+                .contains(valid_user)
+
+            page += 1
 
     def test_new_user_update(self, go_rest_client, valid_user_id):
         update_info = {'status': UserStatus.inactive.value}


### PR DESCRIPTION
This currently causes API to fail with 429 "Too many requests"